### PR TITLE
add deployment, clusterip, lb, ingress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: bash
 sudo: required
 

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -8,6 +8,13 @@ spec:
   containers:
     - name: web
       image: statusxt/web:latest
+      livenessProbe:
+        tcpSocket:
+          port: 8000
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 8000
       volumeMounts:
         - name: app
           mountPath: /app

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.255.1-172.17.255.255 

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 30%
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: statusxt/web:latest
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: html-gen
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
- добавлены проверки в описание пода kubernetes-intro/web-pod.yaml
```
      livenessProbe:
        tcpSocket:
          port: 80
      readinessProbe:
        httpGet:
          path: /index.html
          port: 8000
```
- проверка готовности контейнера завершается неудачно
```
 kubectl describe pod/web
```
- создан deployment web-deploy.yaml
- добавьте блок strategy в манифест (web-deploy.yaml)
```
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0
    maxSurge: 100%
```
- опробованы разные варианты деплоя с крайними значениями maxSurge и maxUnavailable (оба 0, оба 100%, 0 и 100%), за процессом можно наблюдать при помощи ()
- создан и применен манифест для сервиса clusterip web-svc-cip.yaml
```
kubectl apply -f web-svc-cip.yaml
kubectl get services
curl http://<CLUSTER-IP>/index.html
ping <CLUSTER-IP>
arp -an
ip addr show
iptables --list -nv -t nat
```
- включен IPVS для kube-proxy - исправлен ConfigMap (конфигурация Pod, хранящаяся в кластере)
```
kubectl --namespace kube-system edit configmap/kube-proxy
kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
iptables-restore /tmp/iptables.cleanup
```
- установлен MetalLB
```
kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.0/manifests/metallb.yaml
kubectl --namespace metallb-system get all
```
- балансировщик настроен с помощью ConfigMap - создан манифест metallb-config.yaml
- создан, применен и проверен манифест web-svc-lb.yaml:
```
kubectl apply -f web-svc-lb.yaml
kubectl get pods -n kube-system
kubectl --namespace metallb-system get all
kubectl describe svc web-svc-lb
curl http://<LB_address>/index.html
```
- установлен ingress-nginx
```
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
```
- создан и применен файл nginx-lb.yaml c конфигурацией LoadBalancer сервиса
```
kubectl apply -f nginx-lb.yaml
kubectl get service/ingress-nginx
kubectl --namespace ingress-nginx get service/ingress-nginx
curl 172.17.255.2
```
- создан и применен файл web-svc-headless.yaml c конфигурацией Headless сервиса
- настроен ingress-прокси - создан манифест с ресурсом Ingress (web-ingress.yaml)
```
kubectl apply -f web-ingress.yaml
kubectl describe ingress/web
curl http://172.17.255.2/web/index.html
```

## Как запустить проект:
 в kubernetes-networks:
```
kubectl apply -f web-ingress.yaml
```

## Как проверить работоспособность:
в kubernetes-networks:
```
kubectl describe ingress/web
```
перейти в браузере:
```
http://<LB_IP>/web/index.html
```

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
