### PR TITLE
Kubernetes debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ statusxt platform repository
 - [Homework-2 kubernetes-security](#homework-2-kubernetes-security)
 - [Homework-3 kubernetes-networks](#homework-3-kubernetes-networks)
 - [Homework-4 kubernetes-volumes](#homework-4-kubernetes-volumes)
-- [Homework-5 kubernetes-storage](#homework-4-kubernetes-storage)
+- [Homework-5 kubernetes-storage](#homework-5-kubernetes-storage)
+- [Homework-6 kubernetes-debug](#homework-6-kubernetes-debug)
 
 # Homework 1 kubernetes-intro
 ## 1.1 Что было сделано

--- a/kubernetes-debug/kit/deploy/cr-nodes.yaml
+++ b/kubernetes-debug/kit/deploy/cr-nodes.yaml
@@ -1,0 +1,7 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"
+spec:
+  serverNode: "minikube"
+  clientNode: "minikube"

--- a/kubernetes-debug/kit/deploy/cr.yaml
+++ b/kubernetes-debug/kit/deploy/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/deploy/crd.yaml
+++ b/kubernetes-debug/kit/deploy/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/deploy/operator.yaml
+++ b/kubernetes-debug/kit/deploy/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/deploy/rbac.yaml
+++ b/kubernetes-debug/kit/deploy/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/iptables-tailer-2.yaml
+++ b/kubernetes-debug/kit/iptables-tailer-2.yaml
@@ -1,0 +1,45 @@
+---
+  apiVersion: "extensions/v1beta1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "name"
+              - name: "POD_IDENTIFIER_LABEL"
+                value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            imagePullPolicy: Always
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,45 @@
+---
+  apiVersion: "extensions/v1beta1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "label"
+              - name: "POD_IDENTIFIER_LABEL"
+                value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            imagePullPolicy: Always
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/kit-clusterrole.yaml
+++ b/kubernetes-debug/kit/kit-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-iptables-tailer
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","get","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:     ["patch","create"]

--- a/kubernetes-debug/kit/kit-clusterrolebinding.yaml
+++ b/kubernetes-debug/kit/kit-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-iptables-tailer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-iptables-tailer
+subjects:
+- kind: ServiceAccount
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/kit-serviceaccount.yaml
+++ b/kubernetes-debug/kit/kit-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system

--- a/kubernetes-debug/kit/netperf-calico-policy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/strace/agent_daemonset.yaml
+++ b/kubernetes-debug/strace/agent_daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      # hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate


### PR DESCRIPTION
# Выполнено ДЗ №6

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- создан стандартный кластер в GKE из двух узлов (образ - ubuntu, network policy - enabled)
### 6.1.1 kubectl-debug
- установлен kubectl-debug по инструкции
- проверен capbilities у debug контенейра
- изменена версия образа на latest в манифесте strace/agent_daemonset.yaml
```
kubectl apply -f strace/agent_daemonset.yaml
```
### 6.1.2 iptables-tailer
- установлены манифесты для запуска оператора netperf-operator в кластере (лежат в папке deploy в репозитории проекта)
- запущен первый тест, результат - Status: Done
```
kubectl apply -f ./deploy/cr.yaml
kubectl describe netperf.app.example.com/example
```
- добавлена сетевая политика для Calico, чтобы ограничить доступ к подам Netperf и включить логирование в iptables
```
kubectl apply -f netperf-calico-policy.yaml
```
- теперь, если повторно запустить тест, мы увидим, что тест висит в состоянии Started
- проверены журналы на ноде:
```
root@gke-standard-cluster-1-default-pool-9cc4c6d9-hz49:~# journalctl -k | grep calico
Oct 07 05:55:59 gke-standard-cluster-1-default-pool-9cc4c6d9-hz49 kernel: calico-packet: IN=cali754b2327413 OUT=cali5a3ff356618 MAC=ee:ee:ee:ee:ee:ee:5a:be:b1:7b:55:59:08:00 SRC=10.4.0.14 DST=10.4.0.13 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=55072 DF PROTO=TCP SPT=32781 DPT=12865 WINDOW=28400 RES=0x00 SYN URGP=0
Oct 07 05:56:00 gke-standard-cluster-1-default-pool-9cc4c6d9-hz49 kernel: calico-packet: IN=cali754b2327413 OUT=cali5a3ff356618 MAC=ee:ee:ee:ee:ee:ee:5a:be:b1:7b:55:59:08:00 SRC=10.4.0.14 DST=10.4.0.13 LEN=60 TOS=0x00 PREC=0x00 TTL=63 ID=55073 DF PROTO=TCP SPT=32781 DPT=12865 WINDOW=28400 RES=0x00 SYN URGP=0
```
- запущен iptables-tailer с помощью манифеста из репозитория проекта
- создан отдельный сервис-аккаунт с правами на просмотр информации о подах и созданием Event ресурсов
- создан DaemonSet iptables-tailer.yaml с исправвлениями (из сниппетов)
- снова запустим тесты NetPerf и проверены события в кластере Kubernetes:
```
kubectl apply -f iptables-tailer.yaml
kubectl delete -f ./deploy/cr.yaml
kubectl apply -f ./deploy/cr.yaml
describe pod netperf-server-42010a84022d

Events:
  Type     Reason      Age    From                                                        Message
  ----     ------      ----   ----                                                        -------
  Normal   Scheduled   2m24s  default-scheduler                                           Successfully assigned default/netperf-server-42010a84022d to gke-standard-cluster-1-default-pool-9cc4c6d9-hz49
  Normal   Pulled      2m23s  kubelet, gke-standard-cluster-1-default-pool-9cc4c6d9-hz49  Container image "tailoredcloud/netperf:v2.7" already present on machine
  Normal   Created     2m23s  kubelet, gke-standard-cluster-1-default-pool-9cc4c6d9-hz49  Created container
  Normal   Started     2m23s  kubelet, gke-standard-cluster-1-default-pool-9cc4c6d9-hz49  Started container
  Warning  PacketDrop  2m21s  kube-iptables-tailer                                        Packet dropped when receiving traffic from 10.4.0.18
  Warning  PacketDrop  10s    kube-iptables-tailer                                        Packet dropped when receiving traffic from client (10.4.0.18)
```
### 6.1.3 задание со *
- для исправления сетевой политики изменен selector - kit/netperf-calico-policy-2.yaml
- для отображения имен Подов изменена переменная окружения POD_IDENTIFIER на name - kit/iptables-tailer-2.yaml

## Как запустить проект:
в kubernetes-debug:
```
kubectl apply -f kit/
```


## Как проверить работоспособность:
```
kubectl get events -A
kubectl describe pod --selector=app=netperf-operator
```

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
